### PR TITLE
Update minimum CMake version requirement to 3.13

### DIFF
--- a/dune-precice/CMakeLists.txt
+++ b/dune-precice/CMakeLists.txt
@@ -1,6 +1,4 @@
-# We require version CMake version 3.1 to prevent issues
-# with dune_enable_all_packages and older CMake versions.
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 project(dune-precice CXX)
 
 if(NOT (dune-common_DIR OR dune-common_ROOT OR


### PR DESCRIPTION
While trying to build the adapter on Ubuntu 26.04, I got:

```
    default: --- calling all for dune-precice ---
    default: --- calling vcsetup for dune-precice ---
    default: --- calling cmake for dune-precice ---
    default: cmake    "-Ddune-common_DIR=/home/vagrant/dune-dumux/dune-common/build-cmake" "-Ddune-istl_DIR=/home/vagrant/dune-dumux/dune-istl/build-cmake" "-Ddune-geometry_DIR=/home/vagrant/dune-dumux/dune-geometry/build-cmake" "-Ddune-localfunctions_DIR=/home/vagrant/dune-dumux/dune-localfunctions/build-cmake" "-Ddune-uggrid_DIR=/home/vagrant/dune-dumux/dune-uggrid/build-cmake" "-Ddune-grid_DIR=/home/vagrant/dune-dumux/dune-grid/build-cmake" "-Ddune-typetree_DIR=/home/vagrant/dune-dumux/dune-typetree/build-cmake" "-Ddune-functions_DIR=/home/vagrant/dune-dumux/dune-functions/build-cmake"  "/home/vagrant/dune-dumux/dune-adapter/dune-precice"
    default: CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
    default:   Compatibility with CMake < 3.5 has been removed from CMake.
    default: 
    default:   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    default:   to tell CMake that the project requires at least <min> but has been updated
    default:   to work with policies introduced by <max> or earlier.
    default: 
    default:   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
    default: 
    default: 
    default: -- Configuring incomplete, errors occurred!
    default: --- Failed to build dune-precice ---
```

At the same time, I see that other modules (e.g., `dune-common`) require CMake 3.13 (DUNE version 2.9.1). This PR sets the same here.

Similar to https://github.com/maxfirmbach/dune-elastodynamics/pull/2