### PR TITLE
Add a workflow to trigger the system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,13 @@
+name: System tests
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  run-system-tests:
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    with:
+      suites: dune-adapter
+      build_args: DUNE_ADAPTER_PR:${{ github.event.number }},DUNE_ADAPTER_REF:${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Adds a workflow to trigger the system tests using the `trigger-system-tests` label (`dune-adapter` test suite).